### PR TITLE
Add connection validation to the export storage.

### DIFF
--- a/label_studio/io_storages/pachyderm/models.py
+++ b/label_studio/io_storages/pachyderm/models.py
@@ -137,7 +137,7 @@ class PachydermImportStorage(PachydermMixin, ImportStorage):
         self.scan_and_create_links()
 
 
-class PachydermExportStorage(ExportStorage, PachydermMixin):
+class PachydermExportStorage(PachydermMixin, ExportStorage):
 
     def save_annotation(self, annotation):
         if not self.is_mounted:

--- a/label_studio/io_storages/pachyderm/serializers.py
+++ b/label_studio/io_storages/pachyderm/serializers.py
@@ -15,7 +15,7 @@ class PachydermImportStorageSerializer(ImportStorageSerializer):
         fields = '__all__'
 
     def validate(self, data):
-        # Validate local file path
+        # Validate pachyderm resource exists
         data = super(PachydermImportStorageSerializer, self).validate(data)
         storage = PachydermImportStorage(**data)
         try:
@@ -33,7 +33,11 @@ class PachydermExportStorageSerializer(ExportStorageSerializer):
         fields = '__all__'
 
     def validate(self, data):
-        # Validate local file path
+        # Validate pachyderm resource exists
         data = super(PachydermExportStorageSerializer, self).validate(data)
+        storage = PachydermExportStorage(**data)
+        try:
+            storage.validate_connection()
+        except Exception as exc:
+            raise ValidationError(exc)
         return data
-


### PR DESCRIPTION
Fixes bug where a Pachyderm export storage would not correctly error if the repo//branch did not exist.