### PR TITLE
Switch Pachyderm storage to use /pfs instead of /archive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,8 +81,6 @@ RUN python3 label_studio/manage.py collectstatic --no-input && \
 
 ENV HOME=/label-studio
 
-RUN curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v2.6.1/pachctl_2.6.1_amd64.deb\
- && dpkg -i /tmp/pachctl.deb
 
 EXPOSE 8080
 

--- a/label_studio/core/views.py
+++ b/label_studio/core/views.py
@@ -204,11 +204,10 @@ def localfiles_data(request):
 
 def pachyderm_data(request):
     """Serving files for PachydermImportStorage"""
-    path = request.GET.get('d')
     redirect_url = request.GET.get('redirect')
 
     if redirect_url and request.user.is_authenticated:
-        content_type, _ = mimetypes.guess_type(str(path))
+        content_type, _ = mimetypes.guess_type(redirect_url.split("/")[-1])
         content_type = content_type or 'application/octet-stream'
         with urllib.request.urlopen(url=redirect_url) as file:
             file = io.BytesIO(file.read())

--- a/label_studio/core/views.py
+++ b/label_studio/core/views.py
@@ -203,16 +203,16 @@ def localfiles_data(request):
 
 
 def pachyderm_data(request):
-    """Serving files for LocalFilesImportStorage"""
+    """Serving files for PachydermImportStorage"""
     path = request.GET.get('d')
     redirect_url = request.GET.get('redirect')
 
-    if path and redirect_url and request.user.is_authenticated:
-        content_type, encoding = mimetypes.guess_type(str(path))
+    if redirect_url and request.user.is_authenticated:
+        content_type, _ = mimetypes.guess_type(str(path))
         content_type = content_type or 'application/octet-stream'
-        with urllib.request.urlopen(url=redirect_url) as archive:
-            archive = io.BytesIO(archive.read())
-            return RangedFileResponse(request, zipfile.ZipFile(archive).open(path), content_type)
+        with urllib.request.urlopen(url=redirect_url) as file:
+            file = io.BytesIO(file.read())
+            return RangedFileResponse(request, file, content_type)
 
     logging.warning("Not Authenticated")
     return HttpResponseForbidden()

--- a/label_studio/io_storages/pachyderm/models.py
+++ b/label_studio/io_storages/pachyderm/models.py
@@ -106,8 +106,7 @@ class PachydermImportStorageBase(PachydermMixin, ImportStorage):
         if self.use_blob_urls:
             data_key = settings.DATA_UNDEFINED_NAME
             redirect = f"{self.url_scheme}://{self.pachd_address}/pfs/{self.pach_project}/{self.pach_repo}/{self.pach_commit}{key}"
-            path = file.as_uri().replace("@", "/").replace(":", "")
-            return {data_key: f'{settings.HOSTNAME}/data/pfs/?redirect={redirect}&d={path}'}
+            return {data_key: f'{settings.HOSTNAME}/data/pfs/?redirect={redirect}'}
 
         with client.pfs.pfs_file(file) as obj:
             value = json.loads(obj)


### PR DESCRIPTION
For all other cloud storage options (i.e. s3, gcp, azure), the Label Studio server generates a URL that the client later calls to retrieve data. We were hoping for the Pachyderm integration to follow the same paradigm by passing the client a URL that hits the `/pfs` endpoint to retrieve data from Pachyderm. However, we hit a CORS issue with the /pfs server. The /pfs server is designed to accept requests only if the [`Origin` and `Host` headers in the request are the same](https://www.notion.so/2023-04-03-HTTP-file-and-archive-downloads-cfb56fac16e54957b015070416b09e94?pvs=4#4b2c627c469c40208c2f2da9d9e0e84e). Since the client in the Label Studio case is the browser, which usually always sets `Origin`, a request to `/pfs` will surely fail (since Label Studio and pachd proxy aren't running on the same scheme, host, and port).

Thus, we're unable to emulate the pattern the other cloud storage options follow. There was an attempt to follow what the S3 storage option does in the case of non-presigned URLs (it downloads the data, base64 encodes it, and imports it directly to Label Studio), but this didn't prove to work well, [nor is it recommended by Label Studio ](https://labelstud.io/guide/storage#Amazon-S3:~:text=All%20s3%3A//%E2%80%A6%20objects%20will%20be%20preloaded%20into%20Label%20Studio%20tasks%20as%20base64%20codes%2C%20if%20this%20option%20is%20off.).

Our current storage BE implementation uses the `/archive` endpoint to retrieve Pachyderm data from the Label Studio server. Both the `/archive` and `/pfs` endpoints have the same CORS limitation mentioned above. Since, the `/archive` endpoint is currently called on the server side, not on the client side, the request succeeds (since `Origin` isn't set). This PR swaps out the `/archive` endpoint for the easier-to-use `/pfs` endpoint. Even though we were unable to follow the same pattern as other cloud storage options, making this endpoint switch improves performance and removes dependency on pachctl.

Note: `/pfs` endpoint [code change](https://github.com/pachyderm/pachyderm/pull/9187) isn't in master yet

Jira: [INT-1094]

[INT-1094]: https://pachyderm.atlassian.net/browse/INT-1094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ